### PR TITLE
ELK samples for consuming syslog log target events

### DIFF
--- a/elastic/elasticsearch-mq-appliance-template.json
+++ b/elastic/elasticsearch-mq-appliance-template.json
@@ -1,0 +1,117 @@
+{
+  /* -------------------------------------------------------------------------- */
+  /* Sample Elasticsearch 6.5.0 mapping for IBM MQ Appliance syslog log targets */
+  /*                                                                            */
+  /* Copyright 2018 IBM Corporation                                             */
+  /*                                                                            */
+  /* Licensed under the Apache License, Version 2.0 (the "License");            */
+  /* you may not use this file except in compliance with the License.           */
+  /* You may obtain a copy of the License at                                    */
+  /*                                                                            */
+  /* http://www.apache.org/licenses/LICENSE-2.0                                 */
+  /*                                                                            */
+  /* Unless required by applicable law or agreed to in writing, software        */
+  /* distributed under the License is distributed on an "AS IS" BASIS,          */
+  /* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   */
+  /* See the License for the specific language governing permissions and        */
+  /* limitations under the License.                                             */
+  /* -------------------------------------------------------------------------- */
+  "template" : "mqappliance-*",
+  "version"  : 1,
+  "settings" : {
+    "number_of_shards" : 1,
+    "number_of_replicas" : 0
+  },
+  "mappings" : {
+    "doc" : {
+      "properties" : {
+        "@timestamp" : {
+          "type" : "date"
+        },
+        "@version" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "category" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "client" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "gtid" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "host" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "hostname" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "loglevel" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "message" : {
+          "type" : "text"
+        },
+        "msgid" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "object" : {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword",
+              "ignore_above" : 256
+            }
+          }
+        },
+        "object-type" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "port" : {
+          "type" : "integer"
+        },
+        "received-at" : {
+          "type" : "date"
+        },
+        "received-from" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "syslog-facility" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "syslog-severity" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "timestamp" : {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword",
+              "ignore_above" : 256
+            }
+          }
+        },
+        "transaction" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        },
+        "type" : {
+          "type" : "keyword",
+          "ignore_above" : 256
+        }
+      }
+    }
+  }
+}

--- a/elastic/logstash-mq-appliance.conf
+++ b/elastic/logstash-mq-appliance.conf
@@ -1,0 +1,198 @@
+# ----------------------------------------------------------------------
+# Sample Logstash 6.5.0 pipeline for IBM MQ Appliance syslog log targets
+#
+# Copyright 2018 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Input: Listen for syslog information on both TCP and UDP
+# --------------------------------------------------------------------
+
+input {
+
+  tcp {
+    id   => "syslog_tcp"
+    port => 5000
+  }
+
+  udp {
+    id   => "syslog_udp"
+    port => 5000
+  }
+}
+
+# --------------------------------------------------------------------
+# Filter: Parse the syslog messages sent from MQ Appliances so we have
+#         separate fields for key information
+#
+#         Rather than have a single very complex grok we split it up
+#         in to stages that parse sections of a syslog message in turn
+# --------------------------------------------------------------------
+
+filter {
+
+  # ---------------------------------------------------------------
+  # First parse the syslog message PRI field (priority information)
+  #
+  # The following fields are implicitly added:
+  #   - syslog_facility
+  #   - syslog_facility_code
+  #   - syslog_severity
+  #   - syslog_severity_code
+  #
+  # We also add fields to track when and where this log message was
+  # received by logstash
+  # ----------------------------------------------------------------
+
+  syslog_pri {
+    id        => "syslog_pri"
+    add_field => [ "received-at",   "%{@timestamp}" ]
+    add_field => [ "received-from", "%{host}" ]
+  }
+
+  # ----------------------------------------------------------------
+  # Rename/remove the fields added by syslog_pri
+  # ----------------------------------------------------------------
+
+  mutate {
+    id                  => "mutate_syslog_pri"
+    rename              => {
+      "syslog_facility" => "syslog-facility"
+      "syslog_severity" => "syslog-severity"
+    }
+    remove_field        => [ "syslog_facility_code", "syslog_severity_code" ]
+  }
+
+  # ----------------------------------------------------------------------------------
+  # Remove the PRI field and extract the timestamp in either RFC3164 or ISO8601 format
+  # ----------------------------------------------------------------------------------
+
+  grok {
+    id             => "grok_timestamp"
+    break_on_match => true
+    match          => {
+                        "message" => [
+                                       "^<\d+>%{SYSLOGTIMESTAMP:timestamp} %{GREEDYDATA:message}$",
+                                       "^<\d+>%{TIMESTAMP_ISO8601:timestamp} %{GREEDYDATA:message}$" 
+                                     ]
+                       }
+    overwrite      => [ "message" ]
+  }
+
+  # -----------------------------------------------------------------
+  # Parse the timestamp string and use it to set the @timestamp field
+  # We keep the textual timestamp field in case it might be useful
+  # -----------------------------------------------------------------
+
+  date {
+    id    => "date_timestamp"
+    match => [ "timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss", "ISO8601" ]
+  }
+
+  # ----------------------------------------------------------------
+  # Extract the hostname
+  # ----------------------------------------------------------------
+
+  grok {
+    id             => "grok_hostname"
+    match          => { "message" => "^%{SYSLOGHOST:hostname} %{GREEDYDATA:message}$" }
+    overwrite      => [ "message" ]
+  }
+
+  # ----------------------------------------------------------------
+  # Extract the message ID, category and log level
+  # ----------------------------------------------------------------
+
+  grok {
+    id        => "grok_msgid_category_loglevel"
+    match     => { "message" => "^\[%{DATA:msgid}\]\[%{DATA:category}\]\[%{DATA:loglevel}\] %{GREEDYDATA:message}$" }
+    overwrite => [ "message" ]
+  }
+
+  # ------------------------------------------------------------------
+  # Extract the object type and name (if present)
+  #
+  # Do not match if the object type is 'trans' because this is not an
+  # object type, but a transaction identifier that is parsed next.
+  # ------------------------------------------------------------------
+
+  grok {
+    id             => "grok_object"
+    match          => { "message" => "^(?!trans)(?:%{DATA:object-type}\(%{DATA:object}\): )%{GREEDYDATA:message}$" }
+    overwrite      => [ "message" ]
+    tag_on_failure => []
+  }
+
+  # ------------------------------------------------------------------
+  # Extract information about the client and transaction (if present)
+  #
+  # This rule matches two different patterns in the remaining message
+  # text. The first pattern matches the presence of a transaction ID
+  # followed by the transaction type, client IP and global transaction
+  # identifier. The second pattern matches the presence of just a 
+  # client IP - it is used if the first pattern does not match.
+  # -----------------------------------------------------------------
+
+  grok {
+    id             => "grok_transaction"
+    break_on_match => true 
+    match          => {
+                        "message" => [
+                                       "^trans\(%{DATA:transaction}\)(?:\[(?![^\]]*\d)%{DATA:transaction-type}\])?(?:\[%{IP:client}\])?(?: gtid\(%{DATA:gtid}\))?: %{GREEDYDATA:message}$",
+                                       "^(?:\[%{IP:client}\])?: %{GREEDYDATA:message}$"
+                                     ]
+                      }
+    overwrite      => [ "message" ]
+    tag_on_failure => []
+  }
+
+  # ----------------------------------------------------------------
+  # Convert the transaction ID to an integer
+  # ----------------------------------------------------------------
+
+  mutate {
+    id      => "mutate_transaction"
+    convert => {
+      "transaction" => "integer"
+    }
+  }
+}
+
+# --------------------------------------------------------------------
+# Output: Forward the syslog information to Elasticsearch and/or STDOUT
+# --------------------------------------------------------------------
+
+output {
+
+  # -------------
+  # Elasticsearch
+  # -------------
+
+  elasticsearch {
+    id    => "elasticsearch"
+    hosts => ["elasticsearch:9200"]
+    index => "mqappliance-%{+YYYY.MM.dd}"
+    codec => "plain"
+  }
+
+  # --------------------
+  # STDOUT for debugging
+  # --------------------
+
+  # stdout { 
+  #   id    => "stdout"
+  #   codec => "rubydebug"
+  # }
+}

--- a/elastic/readme.md
+++ b/elastic/readme.md
@@ -1,0 +1,16 @@
+# Elastic stack samples for the IBM MQ Appliance
+These samples can be used to consume IBM MQ Appliance log events.
+
+To use these samples:
+
+1. Create an instance of Elasticsearch
+2. Define the mapping to be used when creating an IBM MQ Appliance index
+3. Create an instance of Logstash using the sample pipeline
+4. Configure a syslog log target to stream IBM MQ Appliance log events to Logstash
+5. Create an instance of Kibana to visualize the log events in Elasticsearch
+
+## elasticsearch-mq-appliance-template.json
+Elasticsearch index mapping template for IBM MQ Appliance log events
+
+## logstash-mq-appliance.conf
+Logstash pipeline for processing IBM MQ Appliance log events


### PR DESCRIPTION
These samples can be used to consume IBM MQ Appliance log events from a syslog log target, parse the events using Logstash then output them to Elasticsearch.