### PR TITLE
Extend ELK sample to parse message inserts

### DIFF
--- a/elastic/elasticsearch-mq-appliance-template.json
+++ b/elastic/elasticsearch-mq-appliance-template.json
@@ -2,7 +2,7 @@
   /* -------------------------------------------------------------------------- */
   /* Sample Elasticsearch 6.5.0 mapping for IBM MQ Appliance syslog log targets */
   /*                                                                            */
-  /* Copyright 2018 IBM Corporation                                             */
+  /* Copyright 2018, 2020 IBM Corporation                                       */
   /*                                                                            */
   /* Licensed under the Apache License, Version 2.0 (the "License");            */
   /* you may not use this file except in compliance with the License.           */
@@ -57,6 +57,24 @@
           "ignore_above" : 256
         },
         "message" : {
+          "type" : "text"
+        },
+        "mq-arithinsert1" : {
+          "type" : "integer"
+        },
+        "mq-arithinsert2" : {
+          "type" : "integer"
+        },
+        "mq-commentinsert1" : {
+          "type" : "text"
+        },
+        "mq-commentinsert2" : {
+          "type" : "text"
+        },
+        "mq-commentinsert3" : {
+          "type" : "text"
+        },
+        "mq-extended" : {
           "type" : "text"
         },
         "msgid" : {

--- a/elastic/logstash-mq-appliance.conf
+++ b/elastic/logstash-mq-appliance.conf
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Sample Logstash 6.5.0 pipeline for IBM MQ Appliance syslog log targets
 #
-# Copyright 2018 IBM Corporation
+# Copyright 2018, 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ filter {
   }
 
   # ----------------------------------------------------------------
-  # Extract the message ID, category and log level
+  # Extract the message ID, category and loglevel
   # ----------------------------------------------------------------
 
   grok {
@@ -150,7 +150,7 @@ filter {
     break_on_match => true 
     match          => {
                         "message" => [
-                                       "^trans\(%{DATA:transaction}\)(?:\[(?![^\]]*\d)%{DATA:transaction-type}\])?(?:\[%{IP:client}\])?(?: gtid\(%{DATA:gtid}\))?: %{GREEDYDATA:message}$",
+                                       "^trans\(%{NUMBER:transaction:int}\)(?:\[(?![^\]]*\d)%{DATA:transaction-type}\])?(?:\[%{IP:client}\])?(?: gtid\(%{DATA:gtid}\))?: %{GREEDYDATA:message}$",
                                        "^(?:\[%{IP:client}\])?: %{GREEDYDATA:message}$"
                                      ]
                       }
@@ -158,14 +158,108 @@ filter {
     tag_on_failure => []
   }
 
-  # ----------------------------------------------------------------
-  # Convert the transaction ID to an integer
-  # ----------------------------------------------------------------
+  # ---------------------------------------
+  # Additional processing for MQ log events
+  # ---------------------------------------
 
-  mutate {
-    id      => "mutate_transaction"
-    convert => {
-      "transaction" => "integer"
+  if [category] == "qmgr" {
+
+    # -------------------------------------------------------------------
+    # From version 9.2 the MQ log events can contain extended information
+    # at the end of the message text, including the insert values.
+    # This extended information has the format:
+    #   [ name(value), name(value), ... ]
+    # If present, we parse the extended information in to separate fields
+    # -------------------------------------------------------------------
+
+    # ------------------------------------------------------------
+    # First, extract any extended information to a separate field.
+    # Some messages contain square brackets so we check the data
+    # appears to have the expected format before capturing it.
+    # ------------------------------------------------------------
+
+    grok {
+      id             => "grok_mq_extended"
+      match          => { "message" => "^%{DATA:message}\s*\[(?=\w+\(.*\))%{DATA:mq-extended}\]$" }
+      overwrite      => [ "message" ]
+      tag_on_failure => []
+    }
+
+    # ------------------------------------------------------------------
+    # Now extract the extended message insert fields from last to first.
+    # We do this to protect against any values that contain parentheses,
+    # which might otherwise cause incorrect parsing of the data.
+    # ------------------------------------------------------------------
+
+    # -------------------------------------
+    # Extract comment insert 3 (if present)
+    # -------------------------------------
+
+    grok {
+      id                  => "grok_mq_commentinsert3"
+      match               => { "mq-extended" => "^%{DATA:mq-extended}(?:, )?CommentInsert3\(%{DATA:mq-commentinsert3}\)$" }
+      overwrite           => [ "mq-extended" ]
+      keep_empty_captures => true
+      tag_on_failure      => []
+    }
+
+    # -------------------------------------
+    # Extract comment insert 2 (if present)
+    # -------------------------------------
+
+    grok {
+      id                  => "grok_mq_commentinsert2"
+      match               => { "mq-extended" => "^%{DATA:mq-extended}(?:, )?CommentInsert2\(%{DATA:mq-commentinsert2}\)$" }
+      overwrite           => [ "mq-extended" ]
+      keep_empty_captures => true
+      tag_on_failure      => []
+    }
+
+    # -------------------------------------
+    # Extract comment insert 1 (if present)
+    # -------------------------------------
+
+    grok {
+      id                  => "grok_mq_commentinsert1"
+      match               => { "mq-extended" => "^%{DATA:mq-extended}(?:, )?CommentInsert1\(%{DATA:mq-commentinsert1}\)$" }
+      overwrite           => [ "mq-extended" ]
+      keep_empty_captures => true
+      tag_on_failure      => []
+    }
+
+    # ----------------------------------------
+    # Extract arithmetic insert 2 (if present)
+    # ----------------------------------------
+
+    grok {
+      id                  => "grok_mq_arithinsert2"
+      match               => { "mq-extended" => "^%{DATA:mq-extended}(?:, )?ArithInsert2\(%{NUMBER:mq-arithinsert2:int}\)$" }
+      overwrite           => [ "mq-extended" ]
+      keep_empty_captures => true
+      tag_on_failure      => []
+    }
+
+    # ----------------------------------------
+    # Extract arithmetic insert 1 (if present)
+    # ----------------------------------------
+
+    grok {
+      id                  => "grok_mq_arithinsert1"
+      match               => { "mq-extended" => "^%{DATA:mq-extended}(?:, )?ArithInsert1\(%{NUMBER:mq-arithinsert1:int}\)$" }
+      overwrite           => [ "mq-extended" ]
+      keep_empty_captures => true
+      tag_on_failure      => []
+    }
+
+    # -----------------------------------------------------------------
+    # Remove the mq-extended field if it doesn't contain any other data
+    # -----------------------------------------------------------------
+
+    grok {
+      id             => "grok_prune_mq_extended"
+      match          => { "mq-extended" => "^\s*$" }
+      remove_field   => [ "mq-extended" ]
+      tag_on_failure => []
     }
   }
 }


### PR DESCRIPTION
From MQ 9.2, appliance log target events contain extended information that is appended to the message text, including the value of each runtime insert. This update extends the ELK sample to parse the extra information in to separate fields.